### PR TITLE
Define response-model to customize the response-body

### DIFF
--- a/blog/main.py
+++ b/blog/main.py
@@ -4,6 +4,7 @@ from starlette.responses import Response
 import schemas, models
 from database import engine, SessionLocal
 from sqlalchemy.orm import Session
+from typing import List
 
 
 # the methods used for interacting with the database are required to use the "db" param to fetch the DB-instance.
@@ -54,10 +55,15 @@ def create_blog( request: schemas.Blog, db: Session = Depends( get_db ) ):
 
 
 
-
+# while applying a schema-model to the respone-body where multiple-records exist,
+# then we need to wrap that response-model with List[]. 
+# [ NOTE ]:  List[] will be imported from the "typing" module.
 
 # get blogs from the DB
-@app.get( '/subfolder/blog/', status_code=status.HTTP_200_OK )
+# Using the response-model to display the response in customised manner.
+@app.get( '/subfolder/blog/', 
+        status_code=status.HTTP_200_OK,
+        response_model=List[schemas.blog_rModel] )
 def get_all_blogs( db: Session = Depends( get_db ) ):
     # [ Query: get all rows ] make a query to get all the rows of blogs from the DB
     blogs = db.query( models.Blog ).all()
@@ -69,7 +75,10 @@ def get_all_blogs( db: Session = Depends( get_db ) ):
 
 # Fetch data of a specific blog
 # This func will provide an input field for "id".
-@app.get( '/subfolder/blog/{id}', status_code=status.HTTP_200_OK )    # cannot use spacing inside the 2nd bracket in the path-url
+@app.get( 
+    '/subfolder/blog/{id}', 
+    status_code=status.HTTP_200_OK,
+    response_model=schemas.blog_rModel )    # cannot use spacing inside the 2nd bracket in the path-url
 def get_individual_blog_detail( id, response: Response, db: Session = Depends( get_db ) ):
     blog = db.query( models.Blog ).filter( models.Blog.id == id ).first()
     

--- a/blog/schemas.py
+++ b/blog/schemas.py
@@ -1,17 +1,32 @@
 from pydantic import BaseModel
 
 
-
 # #########################
 #  This file is responsible for creating the frame to recieve the request body from the client.
 # #########################
 
 
 # Blog model Frame ( Pydantic model )
+# In FastAPI, the pydantic models are called as "Schemas"
 # Responsible for receiving the request-body from the client/ user/ browser.
 # [ NOTE ]: It will help to get the request-body from the client/ user while the corresponding API.
 class Blog(BaseModel):
     title: str
     body: str
+
+
+
+
+# response-model class (used for "show specific blog detail" API)
+# We can inherit/ extend the base-model for "Blog"
+class blog_rModel(Blog):
+    title: str
+    body: str
+
+    # [ NOTE ]: Since this class is interacting with the DB through SQLAlchemy ORM, 
+    # so we need to explicitly define the orm_mode to True.
+    class Config():
+        orm_mode = True
+
 
 

--- a/procedure.txt
+++ b/procedure.txt
@@ -119,4 +119,23 @@ Ref [ Aid to build the data-update API ]:  https://www.youtube.com/watch?v=2g1Zj
     Finally, make the "commit()" func to actually take the effect in the db-table.
 
     [ Optional ]: Can return the updated data from the db-table, for that, make a "refresh()" func before that.
+
+
+-----------------> Response Model ( aka response-schema )
     
+18. As the name suggest, For the response rom the API to the client, 
+    we are required to define response-models.
+    By using a response-model, we can customize the response-body sent from the API to the client/ browser.
+    Create another schema-class which will be used for displaying the response-body after hitting the API from the client.
+    The schema-class will be used in the API-url-path as another param.
+    [ NOTE ] Since the response will be a provided from the API, so the response-model should be inside the faspAPI decorator's param instead of the method's param.
+    
+    Use the response-model in the "get_individual_blog_detail" & "get_all_blogs" APIs.
+
+    The response model param defines the response exactly similar to the response-model aka pydantic-model/ schema we have defined inside the "schemas.py" class.
+
+    [ IMPORTANT ]:  If we want to apply response-model to such API where multiple-records exist inside the response-body, 
+    then we need to wrap that with the "List[]" class imported from the "typing" module.
+
+
+


### PR DESCRIPTION
> ### We can define the response sent from the API by using the response-model.
Since it's a pydantic model aka a schema-model, we should construct the model inside the "schemas.py" file.
This response-model  is required to be assigned by using the "response_model" path-url-param.